### PR TITLE
Properly apply status bar offset on full-screen layout

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,7 @@ android {
 }
 
 dependencies {
+    compile 'com.android.support:design:' + project.supportVersion
     compile 'com.android.support:appcompat-v7:' + project.supportVersion
     compile project(":tutoshowcase")
 }

--- a/app/src/main/java/com/github/florent37/tuto/MainActivity.java
+++ b/app/src/main/java/com/github/florent37/tuto/MainActivity.java
@@ -33,7 +33,7 @@ public class MainActivity extends AppCompatActivity {
     protected void displayTuto() {
         TutoShowcase.from(this)
                 .setContentView(R.layout.tuto_sample)
-
+                .setFitsSystemWindows(false)
                 .on(R.id.about)
                 .addCircle()
                 .withBorder()

--- a/app/src/main/java/com/github/florent37/tuto/MainActivity.java
+++ b/app/src/main/java/com/github/florent37/tuto/MainActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.View;
+import android.widget.Toast;
 
 import com.github.florent37.tutoshowcase.TutoShowcase;
 
@@ -32,8 +33,14 @@ public class MainActivity extends AppCompatActivity {
 
     protected void displayTuto() {
         TutoShowcase.from(this)
+                .setListener(new TutoShowcase.Listener() {
+                    @Override
+                    public void onDismissed() {
+                        Toast.makeText(MainActivity.this, "Tutorial dismissed", Toast.LENGTH_SHORT).show();
+                    }
+                })
                 .setContentView(R.layout.tuto_sample)
-                .setFitsSystemWindows(false)
+                .setFitsSystemWindows(true)
                 .on(R.id.about)
                 .addCircle()
                 .withBorder()

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,32 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:fitsSystemWindows="true"
+    tools:openDrawer="start">
 
-    <android.support.v7.widget.Toolbar
-        android:id="@+id/toolbar"
+    <android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:titleTextColor="@android:color/white"
-        android:background="@color/colorPrimary"/>
+        android:layout_height="match_parent"
+        android:fitsSystemWindows="true"
+        tools:context=".main.MainActivity">
+        <android.support.design.widget.AppBarLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:theme="@style/AppTheme.AppBarOverlay">
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:titleTextColor="@android:color/white"
+                android:background="@color/colorPrimary"/>
+        </android.support.design.widget.AppBarLayout>
 
-    <TextView
-        android:id="@+id/swipable"
-        android:background="#333"
-        android:layout_below="@+id/display"
-        android:layout_width="match_parent"
-        android:text="this view is swipable"
-        android:gravity="center"
-        android:textColor="#AFFF"
-        android:layout_height="200dp"
-        android:layout_margin="50dp" />
+        <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fitsSystemWindows="true">
 
-    <Button
-        android:id="@+id/display"
+            <TextView
+                android:id="@+id/swipable"
+                android:background="#333"
+                android:layout_below="@+id/display"
+                android:layout_width="match_parent"
+                android:text="this view is swipable"
+                android:gravity="center"
+                android:textColor="#AFFF"
+                android:layout_height="200dp"
+                android:layout_margin="50dp" />
+
+            <Button
+                android:id="@+id/display"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:text="Display the showcase !"/>
+
+        </RelativeLayout>
+
+    </android.support.design.widget.CoordinatorLayout>
+
+    <android.support.design.widget.NavigationView
+        android:id="@+id/navigation_drawer"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:text="Display the showcase !"/>
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:background="#F00"
+        android:fitsSystemWindows="true"/>
 
-</RelativeLayout>
+</android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -6,9 +6,9 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
-
         <item name="actionMenuTextColor">@android:color/white</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 
-    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
 

--- a/tutoshowcase/src/main/java/com/github/florent37/tutoshowcase/TutoShowcase.java
+++ b/tutoshowcase/src/main/java/com/github/florent37/tutoshowcase/TutoShowcase.java
@@ -35,12 +35,17 @@ import com.github.florent37.tutoshowcase.shapes.RoundRect;
 
 public final class TutoShowcase {
 
+    public interface Listener {
+        void onDismissed();
+    }
+
     public static final float DEFAULT_ADDITIONAL_RADIUS_RATIO = 1.5f;
     private static final String SHARED_TUTO = "SHARED_TUTO";
     private FrameLayout container;
     private TutoView tutoView;
     private SharedPreferences sharedPreferences;
     private boolean fitsSystemWindows = false;
+    private Listener listener;
 
     private TutoShowcase(@NonNull Activity activity) {
         this.sharedPreferences = activity.getSharedPreferences(SHARED_TUTO, Context.MODE_PRIVATE);
@@ -80,6 +85,11 @@ public final class TutoShowcase {
         return this;
     }
 
+    public TutoShowcase setListener(Listener listener) {
+        this.listener = listener;
+        return this;
+    }
+
     public TutoShowcase setContentView(@LayoutRes int content) {
         View child = LayoutInflater.from(tutoView.getContext()).inflate(content, container, false);
         container.addView(child, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
@@ -97,6 +107,9 @@ public final class TutoShowcase {
                         ViewParent parent = view.getParent();
                         if (parent instanceof ViewGroup) {
                             ((ViewGroup) parent).removeView(view);
+                        }
+                        if(listener != null) {
+                            listener.onDismissed();
                         }
                     }
                 }).start();


### PR DESCRIPTION
When displaying circle above view position in layout with
fitsSystemWindows flag, circle Y positon is adjusted for
status bar height. This is not correct.

This change calculate the offset depending on
fitsSystemWindows flag on content layout.

By default we try to guess fitsSystemWindows flag by checking
direct child of content container, but we can always enforce
out own setting by calling setFitsSystemWindows() setter.